### PR TITLE
Update package.json add types in "exports"

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "author": "William Swanson",
   "exports": {
     ".": {
+      "types": "./lib/src/index.d.ts",
       "import": "./lib/index.mjs",
       "require": "./lib/index.js"
     },


### PR DESCRIPTION
Typescript 4.7+ includes new the new "Node16"/"NodeNext" options for configuration options "module" and "moduleResolution". These adhere strictly to Node's package.json "exports" fields rules -- when that field is set the other root fields (like "types") are ignored.
I've added "types": "./lib/src/index.d.ts", in the "exports"