### PR TITLE
Stop using rollup-plugin-mjs-entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,33 +17,40 @@
   },
   "license": "MIT",
   "author": "William Swanson",
+  "type": "module",
   "exports": {
     ".": {
-      "types": "./lib/src/index.d.ts",
-      "import": "./lib/index.mjs",
-      "require": "./lib/index.js"
+      "import": {
+        "types": "./lib/src/index.d.ts",
+        "default": "./lib/rfc4648.js"
+      },
+      "require": {
+        "types": "./lib/src/index.d.ts",
+        "default": "./lib/cjs/rfc4648.js"
+      }
     },
     "./package.json": "./package.json"
   },
-  "main": "./lib/index.js",
+  "main": "./lib/cjs/rfc4648.js",
   "module": "./lib/rfc4648.js",
   "types": "./lib/src/index.d.ts",
   "files": [
-    "CHANGELOG.md",
-    "lib/*",
-    "README.md",
-    "src/*"
+    "/CHANGELOG.md",
+    "/lib/*",
+    "/package.json",
+    "/README.md",
+    "/src/index.flow.js"
   ],
   "scripts": {
     "clean": "rimraf lib",
     "fix": "eslint . --fix",
-    "lib": "rollup -c",
+    "lib": "rollup -c && echo '{\"type\":\"commonjs\"}' > lib/cjs/package.json",
     "lint": "eslint .",
     "precommit": "lint-staged && npm-run-all types test",
-    "prepare": "npm-run-all clean -p lib types",
+    "prepare": "husky install && npm-run-all clean -p lib types",
     "test": "nyc mocha 'test/**/*.ts'",
     "types": "tsc",
-    "verify": "npm-run-all lint types test"
+    "verify": "npm-run-all lib lint types test"
   },
   "lint-staged": {
     "*.{js,ts}": "eslint"
@@ -77,7 +84,6 @@
     "rollup": "^2.47.0",
     "rollup-plugin-filesize": "^10.0.0",
     "rollup-plugin-flow-entry": "^0.3.5",
-    "rollup-plugin-mjs-entry": "^0.1.1",
     "sucrase": "^3.18.1",
     "typescript": "^4.1.2"
   }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,7 +2,6 @@ import babel from '@rollup/plugin-babel'
 import resolve from '@rollup/plugin-node-resolve'
 import filesize from 'rollup-plugin-filesize'
 import flowEntry from 'rollup-plugin-flow-entry'
-import mjs from 'rollup-plugin-mjs-entry'
 
 import packageJson from './package.json'
 
@@ -35,7 +34,6 @@ export default {
     resolve(resolveOpts),
     babel(babelOpts),
     flowEntry({ types: 'src/index.flow.js' }),
-    filesize(),
-    mjs({ includeDefault: true })
+    filesize()
   ]
 }


### PR DESCRIPTION
This plugin seems to be causing problems. Instead, just bundle the package twice as CJS and MJS.

We keep the file extensions as ".js", since that's the most compatible.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205775922167453