### PR TITLE
Add file extension to import path

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import {
   ParseOptions,
   stringify,
   StringifyOptions
-} from './codec'
+} from './codec.js'
 
 const base16Encoding: Encoding = {
   chars: '0123456789ABCDEF',


### PR DESCRIPTION
Prevents the following types of errors:

npm error ../../node_modules/rfc4648/lib/src/index.d.ts(1,66): error TS2834: Relative import paths need explicit file extensions in ECMAScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Consider adding an extension to the import path.